### PR TITLE
エントランスページのロジックを実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
           </Route>
         </Switch>
         <Switch>
-          <Route path="/enter-room">
+          <Route path="/enter-room/:id">
             <EnterRoom />
           </Route>
         </Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,56 +1,14 @@
-import { BrowserRouter, Link, Switch, Route } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 
 import { Header } from "./components/Header";
-import { CreateRoom } from "./pages/CreateRoom";
-import { HostEntrance } from "./pages/HostEntrance";
-import { Game } from "./pages/Game";
-import { EnterRoom } from "./pages/EnterRoom";
-import { Top } from "./pages/Top";
-import { GuestEntrance } from "./pages/GuestEntrance";
+import { Router } from "./router/Router";
 
 function App() {
   return (
     <div className="h-screen w-screen font-body text-base bg-yellow-50 text-gray-500">
       <BrowserRouter>
         <Header />
-        <div>
-          {/* <Link to="/">Top</Link>
-        <Link to="/create-room">CreateRoom</Link>
-        <Link to="/join-room">JoinRoom</Link>
-        <Link to="/host-entrance">Entrance</Link>
-        <Link to="/guest-entrance">Entrance</Link>
-        <Link to="/game">Game</Link> */}
-        </div>
-        <Switch>
-          <Route exact path="/">
-            <Top />
-          </Route>
-        </Switch>
-        <Switch>
-          <Route path="/create-room">
-            <CreateRoom />
-          </Route>
-        </Switch>
-        <Switch>
-          <Route path="/enter-room/:id">
-            <EnterRoom />
-          </Route>
-        </Switch>
-        <Switch>
-          <Route path="/host-entrance">
-            <HostEntrance />
-          </Route>
-        </Switch>
-        <Switch>
-          <Route path="/guest-entrance">
-            <GuestEntrance />
-          </Route>
-        </Switch>
-        <Switch>
-          <Route path="/game">
-            <Game />
-          </Route>
-        </Switch>
+        <Router />
       </BrowserRouter>
     </div>
   );

--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, VFC } from "react";
 
 type Props = {
+  value?: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   id?: string;
   fontSize?: string;
@@ -9,6 +10,7 @@ type Props = {
 };
 
 export const InputBox: VFC<Props> = ({
+  value,
   onChange,
   id,
   fontSize = "xl",
@@ -18,6 +20,7 @@ export const InputBox: VFC<Props> = ({
   return (
     <>
       <input
+        value={value}
         onChange={onChange}
         id={id}
         className={`inline-block border-2 rounded-md font-${fontSize} w-${width} h-${height} sm:w-${

--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -16,8 +16,8 @@ export const CreateRoom: VFC = () => {
       alert("名前を入力してください");
       return;
     }
-    createNewRoom(userName);
-    history.push("/host-entrance", { userName });
+    const roomId = await createNewRoom(userName);
+    history.push("/host-entrance", { userName, roomId });
   };
 
   return (

--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -16,8 +16,13 @@ export const CreateRoom: VFC = () => {
       alert("名前を入力してください");
       return;
     }
-    const roomId = await createNewRoom(userName);
-    history.push("/host-entrance", { userName, roomId });
+    try {
+      const roomId = await createNewRoom(userName);
+      history.push("/host-entrance", { userName, roomId });
+    } catch (e) {
+      console.log(e);
+      alert("通信エラーです。もう一度お試しください");
+    }
   };
 
   return (

--- a/src/pages/EnterRoom.tsx
+++ b/src/pages/EnterRoom.tsx
@@ -1,11 +1,16 @@
 import { ChangeEvent, useState, VFC } from "react";
-import { useHistory } from "react-router";
+import { useHistory, useParams } from "react-router";
 import { PrimaryButton } from "../components/Buttons";
 import { InputBox } from "../components/InputBox";
 import { addGuestUser } from "../utils/firestore/addGuestUser";
 
+type Params = {
+  id: string;
+};
+
 export const EnterRoom: VFC = () => {
-  const [roomId, setRoomId] = useState<string>();
+  const { id } = useParams<Params>();
+  const [roomId, setRoomId] = useState<string>(id);
   const [userName, setUserName] = useState<string>();
   const onChangeRoomId = (event: ChangeEvent<HTMLInputElement>) => {
     setRoomId(event.target.value);
@@ -44,7 +49,7 @@ export const EnterRoom: VFC = () => {
         <div className="flex flex-col space-y-8 items-center mt-7 mb-14 ">
           <div className="text-center">
             <p className="text-xl sm:text-2xl pb-2">ルームID</p>
-            <InputBox onChange={onChangeRoomId} />
+            <InputBox value={roomId} onChange={onChangeRoomId} />
           </div>
           <div className="text-center">
             <p className="text-xl sm:text-2xl pb-2">名前</p>

--- a/src/pages/EnterRoom.tsx
+++ b/src/pages/EnterRoom.tsx
@@ -25,8 +25,8 @@ export const EnterRoom: VFC = () => {
       return;
     }
     try {
-      await addGuestUser(roomId, userName);
-      history.push(`/guest-entrance/${roomId}`, { roomId, userName });
+      const userId = await addGuestUser(roomId, userName);
+      history.push(`/guest-entrance/${roomId}`, { roomId, userName, userId });
     } catch (e) {
       console.log(e);
       alert("通信エラーです。もう一度お試しください");

--- a/src/pages/EnterRoom.tsx
+++ b/src/pages/EnterRoom.tsx
@@ -26,12 +26,12 @@ export const EnterRoom: VFC = () => {
     }
     try {
       await addGuestUser(roomId, userName);
+      history.push(`/guest-entrance/${roomId}`, { roomId, userName });
     } catch (e) {
       console.log(e);
-      return;
+      alert("通信エラーです。もう一度お試しください");
     }
     // TODO:途中入室を可能にする必要あり
-    history.push(`/guest-entrance/${roomId}`, { roomId, userName });
   };
 
   return (

--- a/src/pages/EnterRoom.tsx
+++ b/src/pages/EnterRoom.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, useState, VFC } from "react";
 import { useHistory } from "react-router";
 import { PrimaryButton } from "../components/Buttons";
 import { InputBox } from "../components/InputBox";
+import { addGuestUser } from "../utils/firestore/addGuestUser";
 
 export const EnterRoom: VFC = () => {
   const [roomId, setRoomId] = useState<string>();
@@ -15,7 +16,7 @@ export const EnterRoom: VFC = () => {
 
   const history = useHistory();
 
-  const onClickCreateRoom = () => {
+  const onClickCreateRoom = async () => {
     if (!roomId) {
       alert("ルームIDを入力してください");
       return;
@@ -23,9 +24,14 @@ export const EnterRoom: VFC = () => {
       alert("名前を入力してください");
       return;
     }
-    console.log("enter room");
+    try {
+      await addGuestUser(roomId, userName);
+    } catch (e) {
+      console.log(e);
+      return;
+    }
     // TODO:途中入室を可能にする必要あり
-    history.push("/guest-entrance", { roomId, userName });
+    history.push(`/guest-entrance/${roomId}`, { roomId, userName });
   };
 
   return (

--- a/src/pages/GuestEntrance.tsx
+++ b/src/pages/GuestEntrance.tsx
@@ -1,10 +1,12 @@
-import { useState, VFC } from "react";
+import { useEffect, useState, VFC } from "react";
 import { useHistory, useLocation } from "react-router";
 import { SecondButton } from "../components/Buttons";
 import { ConfirmModal } from "../components/Modals";
 import { Information } from "../components/Information";
 import { LeavingRoom } from "../utils/LeavingRoom";
 import { removeUser } from "../utils/firestore/removeUser";
+import { doc, onSnapshot } from "@firebase/firestore";
+import { db } from "../service/firebase";
 
 // 前ページでuseHistoryでstateを渡している。stateがundefinedのときはエラー表示が出るようにすれば、url直入力で入れなくさせられるはず。
 type State = {
@@ -34,6 +36,15 @@ export const GuestEntrance: VFC = () => {
     removeUser(roomId, userName, userId);
     history.push("/");
   };
+
+  useEffect(() => {
+    return onSnapshot(doc(db, `hgs/v1/rooms/${roomId}`), (doc) => {
+      const data = doc.data();
+      if (data) {
+        if (data.isDuringGame === true) history.push("/game");
+      }
+    });
+  }, [history, roomId]);
 
   return (
     <>

--- a/src/pages/GuestEntrance.tsx
+++ b/src/pages/GuestEntrance.tsx
@@ -3,7 +3,6 @@ import { useHistory, useLocation } from "react-router";
 import { SecondButton } from "../components/Buttons";
 import { ConfirmModal } from "../components/Modals";
 import { Information } from "../components/Information";
-import { LeavingRoom } from "../utils/LeavingRoom";
 import { removeUser } from "../utils/firestore/removeUser";
 import { doc, onSnapshot } from "@firebase/firestore";
 import { db } from "../service/firebase";
@@ -14,10 +13,6 @@ type State = {
   userName: string;
   userId: string;
 };
-
-// HostEntranceと書き方を統一
-// useContextについて復習
-// userIdをremoveUser関数に渡す
 
 export const GuestEntrance: VFC = () => {
   const location = useLocation<State>();

--- a/src/pages/GuestEntrance.tsx
+++ b/src/pages/GuestEntrance.tsx
@@ -4,10 +4,22 @@ import { SecondButton } from "../components/Buttons";
 import { ConfirmModal } from "../components/Modals";
 import { Information } from "../components/Information";
 import { LeavingRoom } from "../utils/LeavingRoom";
+import { removeUser } from "../utils/firestore/removeUser";
 
 // 前ページでuseHistoryでstateを渡している。stateがundefinedのときはエラー表示が出るようにすれば、url直入力で入れなくさせられるはず。
+type State = {
+  roomId: string;
+  userName: string;
+  userId: string;
+};
+
+// HostEntranceと書き方を統一
+// useContextについて復習
+// userIdをremoveUser関数に渡す
+
 export const GuestEntrance: VFC = () => {
-  const state = useLocation().state as any;
+  const location = useLocation<State>();
+  const { userName, roomId, userId } = location.state;
   const [isOpen, setIsOpen] = useState(false);
   const history = useHistory();
 
@@ -19,13 +31,13 @@ export const GuestEntrance: VFC = () => {
   };
 
   const returnToTopPage = () => {
-    LeavingRoom();
+    removeUser(roomId, userName, userId);
     history.push("/");
   };
 
   return (
     <>
-      <Information roomId={state.roomId} userName={state.userName} />
+      <Information roomId={roomId} userName={userName} />
       <div className="flex flex-col h-3/4 justify-center items-center">
         <p className="text-lg sm:text-2xl text-blue-500">
           ゲームの開始を待っています...

--- a/src/pages/HostEntrance.tsx
+++ b/src/pages/HostEntrance.tsx
@@ -8,6 +8,8 @@ import {
 } from "../components/Buttons";
 import { ConfirmModal } from "../components/Modals";
 import { useModals } from "../hooks/useModals";
+import { doc, onSnapshot } from "@firebase/firestore";
+import { db } from "../service/firebase";
 
 // 前ページでuseHistoryでstateを渡している。stateがundefinedのときは404ページに遷移するようにすれば、url直入力で入れなくさせられるはず。
 
@@ -19,6 +21,10 @@ type State = {
 export const HostEntrance: VFC = () => {
   const location = useLocation<State>();
   const { userName, roomId } = location.state;
+
+  const snapshot = onSnapshot(doc(db, `hgs/v1/rooms`, `${roomId}`), (doc) => {
+    console.log(doc.data());
+  });
 
   const history = useHistory();
   const { isOpen, openModal, closeModal } = useModals();
@@ -41,7 +47,7 @@ export const HostEntrance: VFC = () => {
   };
 
   const users = [
-    "ドナルド",
+    userName,
     "スティーブ",
     "太郎",
     "炭治郎",

--- a/src/pages/HostEntrance.tsx
+++ b/src/pages/HostEntrance.tsx
@@ -1,6 +1,6 @@
 import { VFC } from "react";
 import { message, Upload } from "antd";
-import { useHistory } from "react-router";
+import { useHistory, useLocation } from "react-router";
 import {
   PrimaryButton,
   SecondButton,
@@ -9,8 +9,17 @@ import {
 import { ConfirmModal } from "../components/Modals";
 import { useModals } from "../hooks/useModals";
 
-// 前ページでuseHistoryでstateを渡している。stateがundefinedのときはエラー表示が出るようにすれば、url直入力で入れなくさせられるはず。
+// 前ページでuseHistoryでstateを渡している。stateがundefinedのときは404ページに遷移するようにすれば、url直入力で入れなくさせられるはず。
+
+type State = {
+  userName: string;
+  roomId: string;
+};
+
 export const HostEntrance: VFC = () => {
+  const location = useLocation<State>();
+  const { userName, roomId } = location.state;
+
   const history = useHistory();
   const { isOpen, openModal, closeModal } = useModals();
 
@@ -24,7 +33,6 @@ export const HostEntrance: VFC = () => {
     history.push("/");
   };
 
-  const roomId = "abcdef"; // firestoreから取得するようにする
   const invitingUrl = `https://haateiu-game-supporter/enter-room/${roomId}`;
 
   const copy = (data: string) => {
@@ -65,7 +73,12 @@ export const HostEntrance: VFC = () => {
             />
           </li>
           <li className="space-x-2">
-            ルーム番号：<span>{roomId}</span>
+            ルームID：
+            <input
+              className="w-2/5 sm:w-3/5 sm:max-w-sm px-1"
+              readOnly
+              value={roomId}
+            />
             <ThirdButton
               text={"コピー"}
               onClick={() => copy(roomId)}

--- a/src/pages/HostEntrance.tsx
+++ b/src/pages/HostEntrance.tsx
@@ -25,11 +25,11 @@ export const HostEntrance: VFC = () => {
   const [usersName, setUsersName] = useState([userName]);
 
   useEffect(() => {
-    onSnapshot(doc(db, `hgs/v1/rooms/${roomId}`), (doc) => {
-      console.log("snapshot start");
+    return onSnapshot(doc(db, `hgs/v1/rooms/${roomId}`), (doc) => {
       const data = doc.data();
       if (data) {
         setUsersName(data.usersName);
+        console.log("changed");
       }
     });
   }, [roomId]);

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,0 +1,35 @@
+import { Switch, Route } from "react-router-dom";
+import { CreateRoom } from "../pages/CreateRoom";
+import { EnterRoom } from "../pages/EnterRoom";
+import { Game } from "../pages/Game";
+import { GuestEntrance } from "../pages/GuestEntrance";
+import { HostEntrance } from "../pages/HostEntrance";
+import { Top } from "../pages/Top";
+
+export const Router = () => {
+  return (
+    <Switch>
+      <Route exact path="/">
+        <Top />
+      </Route>
+      <Route path="/create-room">
+        <CreateRoom />
+      </Route>
+      <Route exact path="/enter-room">
+        <EnterRoom />
+      </Route>
+      <Route path="/enter-room/:id">
+        <EnterRoom />
+      </Route>
+      <Route path="/host-entrance">
+        <HostEntrance />
+      </Route>
+      <Route path="/guest-entrance">
+        <GuestEntrance />
+      </Route>
+      <Route path="/game">
+        <Game />
+      </Route>
+    </Switch>
+  );
+};

--- a/src/utils/firestore/addGuestUser.ts
+++ b/src/utils/firestore/addGuestUser.ts
@@ -1,0 +1,7 @@
+import { collection, doc, serverTimestamp, setDoc } from "@firebase/firestore";
+import { db } from "../../service/firebase";
+
+export const addGuestUser = async (roomId: string, userName: string) => {
+  const usersRef = doc(collection(db, `hgs/v1/rooms/${roomId}/users`));
+  await setDoc(usersRef, { displayName: userName, isHost: false });
+};

--- a/src/utils/firestore/addGuestUser.ts
+++ b/src/utils/firestore/addGuestUser.ts
@@ -1,7 +1,17 @@
-import { collection, doc, serverTimestamp, setDoc } from "@firebase/firestore";
+import {
+  arrayUnion,
+  collection,
+  doc,
+  setDoc,
+  updateDoc,
+} from "@firebase/firestore";
 import { db } from "../../service/firebase";
 
 export const addGuestUser = async (roomId: string, userName: string) => {
+  // TODO:トランザクション
+  const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
+  await updateDoc(roomRef, { usersName: arrayUnion(userName) });
   const usersRef = doc(collection(db, `hgs/v1/rooms/${roomId}/users`));
   await setDoc(usersRef, { displayName: userName, isHost: false });
+  return usersRef.id;
 };

--- a/src/utils/firestore/createNewGame.ts
+++ b/src/utils/firestore/createNewGame.ts
@@ -1,0 +1,17 @@
+import { collection, doc, getDocs, setDoc } from "@firebase/firestore";
+import { db } from "../../service/firebase";
+import { createAlphabetArray } from "../createAlphabetArray";
+import { shuffleArray } from "../shuffleArray";
+
+export const createNewGame = async (roomId: string) => {
+  const usersRef = collection(db, `hgs/v1/rooms/${roomId}/users`);
+  const users = await getDocs(usersRef);
+  const alphabetArray = shuffleArray(createAlphabetArray(users.size));
+  users.forEach((userDoc) => {
+    const gameRef = doc(
+      collection(db, `hgs/v1/rooms/${roomId}/users/${userDoc.id}/games`)
+    );
+    const alphabet = alphabetArray.shift();
+    setDoc(gameRef, { userTheme: alphabet, answers: [] });
+  });
+};

--- a/src/utils/firestore/createNewGame.ts
+++ b/src/utils/firestore/createNewGame.ts
@@ -1,17 +1,38 @@
-import { collection, doc, getDocs, setDoc } from "@firebase/firestore";
+import { collection, doc, getDocs, runTransaction } from "@firebase/firestore";
 import { db } from "../../service/firebase";
 import { createAlphabetArray } from "../createAlphabetArray";
 import { shuffleArray } from "../shuffleArray";
 
 export const createNewGame = async (roomId: string) => {
+  const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
   const usersRef = collection(db, `hgs/v1/rooms/${roomId}/users`);
-  const users = await getDocs(usersRef);
-  const alphabetArray = shuffleArray(createAlphabetArray(users.size));
-  users.forEach((userDoc) => {
-    const gameRef = doc(
-      collection(db, `hgs/v1/rooms/${roomId}/users/${userDoc.id}/games`)
-    );
-    const alphabet = alphabetArray.shift();
-    setDoc(gameRef, { userTheme: alphabet, answers: [] });
-  });
+  const usersDoc = await getDocs(usersRef);
+  const alphabetArray: Array<string> = shuffleArray(
+    createAlphabetArray(usersDoc.size)
+  );
+
+  try {
+    await runTransaction(db, async (transaction) => {
+      const roomDoc = await transaction.get(roomRef);
+      if (!roomDoc.exists()) {
+        throw new Error("Document does not exist!");
+      }
+      const newGameCount: number = roomDoc.data().gameCount + 1;
+      transaction.update(roomRef, {
+        gameCount: newGameCount,
+      });
+      const gameId = `game${newGameCount}`;
+      usersDoc.forEach((userDoc) => {
+        const gameRef = doc(
+          db,
+          `hgs/v1/rooms/${roomId}/users/${userDoc.id}/games/${gameId}`
+        );
+        const alphabet = alphabetArray.shift();
+        transaction.set(gameRef, { userTheme: alphabet, answers: [] });
+      });
+    });
+    console.log("Transaction successfully committed!");
+  } catch (e) {
+    console.log("Transaction failed: ", e);
+  }
 };

--- a/src/utils/firestore/createNewGame.ts
+++ b/src/utils/firestore/createNewGame.ts
@@ -20,6 +20,7 @@ export const createNewGame = async (roomId: string) => {
       const newGameCount: number = roomDoc.data().gameCount + 1;
       transaction.update(roomRef, {
         gameCount: newGameCount,
+        isDuringGame: true,
       });
       const gameId = `game${newGameCount}`;
       usersDoc.forEach((userDoc) => {

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -4,7 +4,7 @@ import { db } from "../../service/firebase";
 export const createNewRoom = async (name: string) => {
   const newRoomRef = doc(collection(db, "hgs/v1/rooms"));
   const usersRef = doc(collection(db, `hgs/v1/rooms/${newRoomRef.id}/users`));
-  await setDoc(newRoomRef, { createdAt: serverTimestamp() });
+  await setDoc(newRoomRef, { createdAt: serverTimestamp(), usersName: [name] });
   await setDoc(usersRef, { displayName: name, isHost: true });
   return newRoomRef.id;
 };

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -6,4 +6,5 @@ export const createNewRoom = async (name: string) => {
   const usersRef = doc(collection(db, `hgs/v1/rooms/${newRoomRef.id}/users`));
   await setDoc(newRoomRef, { createdAt: serverTimestamp() });
   await setDoc(usersRef, { displayName: name, isHost: true });
+  return newRoomRef.id;
 };

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -2,9 +2,9 @@ import { collection, doc, serverTimestamp, setDoc } from "@firebase/firestore";
 import { db } from "../../service/firebase";
 
 export const createNewRoom = async (name: string) => {
-  const newRoomRef = doc(collection(db, "hgs/v1/rooms"));
-  const usersRef = doc(collection(db, `hgs/v1/rooms/${newRoomRef.id}/users`));
-  await setDoc(newRoomRef, { createdAt: serverTimestamp(), usersName: [name] });
+  const roomsRef = doc(collection(db, "hgs/v1/rooms"));
+  const usersRef = doc(collection(db, `hgs/v1/rooms/${roomsRef.id}/users`));
+  await setDoc(roomsRef, { createdAt: serverTimestamp(), usersName: [name] });
   await setDoc(usersRef, { displayName: name, isHost: true });
-  return newRoomRef.id;
+  return roomsRef.id;
 };

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -4,7 +4,12 @@ import { db } from "../../service/firebase";
 export const createNewRoom = async (name: string) => {
   const roomsRef = doc(collection(db, "hgs/v1/rooms"));
   const usersRef = doc(collection(db, `hgs/v1/rooms/${roomsRef.id}/users`));
-  await setDoc(roomsRef, { createdAt: serverTimestamp(), usersName: [name] });
+  await setDoc(roomsRef, {
+    createdAt: serverTimestamp(),
+    usersName: [name],
+    gameCount: 0,
+    isDuringGame: false,
+  });
   await setDoc(usersRef, { displayName: name, isHost: true });
   return roomsRef.id;
 };

--- a/src/utils/firestore/removeUser.ts
+++ b/src/utils/firestore/removeUser.ts
@@ -1,0 +1,14 @@
+import { arrayRemove, deleteDoc, doc, updateDoc } from "@firebase/firestore";
+import { db } from "../../service/firebase";
+
+export const removeUser = async (
+  roomId: string,
+  userName: string,
+  userId: string
+) => {
+  // TODO:トランザクション
+  const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
+  await updateDoc(roomRef, { usersName: arrayRemove(userName) });
+  const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
+  await deleteDoc(userRef);
+};

--- a/src/utils/shuffleArray.ts
+++ b/src/utils/shuffleArray.ts
@@ -1,0 +1,9 @@
+// 配列の要素をランダムに並べ替えて返す（ダステンフェルドの手法)
+export const shuffleArray = (array: Array<any>) => {
+  let result = array;
+  for (let i = result.length; 1 < i; i--) {
+    const k = Math.floor(Math.random() * i);
+    [result[k], result[i - 1]] = [result[i - 1], result[k]];
+  }
+  return result;
+};


### PR DESCRIPTION
## やったこと
 - ホスト用ページのルームID表示場所にfirestoreから取得したroomIdを表示
 - ゲスト用ページへのリンクを表示し、そこにアクセスするとルームIDが入力済み
-  ルーム入室をクリックしたゲストをfirestoreのusersに追加
- firestoreのusersを監視してユーザー名一覧を更新
- ゲーム開始ボタンをクリックするとgamesサブコレクションに新しいgameを作成し、ホストとゲストをゲームページに遷移
- ルーティングの整理
