### PR TITLE
ブラウザバックの対策を導入

### DIFF
--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -17,8 +17,10 @@ export const CreateRoom: VFC = () => {
       return;
     }
     try {
-      const roomId = await createNewRoom(userName);
-      history.push("/host-entrance", { userName, roomId });
+      const ids = await createNewRoom(userName);
+      const userInfo = { ...ids, userName };
+      localStorage.setItem("userInfo", JSON.stringify(userInfo));
+      history.push("/host-entrance");
     } catch (e) {
       console.log(e);
       alert("通信エラーです。もう一度お試しください");

--- a/src/pages/EnterRoom.tsx
+++ b/src/pages/EnterRoom.tsx
@@ -38,7 +38,9 @@ export const EnterRoom: VFC = () => {
     }
     try {
       const userId = await addGuestUser(roomId, userName);
-      history.push(`/guest-entrance/${roomId}`, { roomId, userName, userId });
+      const userInfo = { roomId, userId, userName };
+      localStorage.setItem("userInfo", JSON.stringify(userInfo));
+      history.push(`/guest-entrance`);
     } catch (e) {
       console.log(e);
       alert("通信エラーです。もう一度お試しください");

--- a/src/pages/HostEntrance.tsx
+++ b/src/pages/HostEntrance.tsx
@@ -21,10 +21,17 @@ type State = {
 
 export const HostEntrance: VFC = () => {
   const location = useLocation<State>();
-  const { userName, roomId } = location.state;
+  const { userName, roomId } = location.state
+    ? location.state
+    : window.history.state;
   const [usersName, setUsersName] = useState([userName]);
+  console.log(location.state);
+  // console.log(window.history.state);
+  const storageRoomId = localStorage.getItem("roomId");
+  console.log(storageRoomId);
 
   useEffect(() => {
+    window.history.pushState(location.state, "", null);
     return onSnapshot(doc(db, `hgs/v1/rooms/${roomId}`), (doc) => {
       const data = doc.data();
       if (data) {
@@ -32,7 +39,7 @@ export const HostEntrance: VFC = () => {
         console.log("changed");
       }
     });
-  }, [roomId]);
+  }, [location.state, roomId]);
 
   const history = useHistory();
   const { isOpen, openModal, closeModal } = useModals();

--- a/src/pages/HostEntrance.tsx
+++ b/src/pages/HostEntrance.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, VFC } from "react";
 import { message, Upload } from "antd";
-import { useHistory, useLocation } from "react-router";
+import { useHistory } from "react-router";
 import {
   PrimaryButton,
   SecondButton,
@@ -11,27 +11,15 @@ import { useModals } from "../hooks/useModals";
 import { doc, onSnapshot } from "@firebase/firestore";
 import { db } from "../service/firebase";
 import { createNewGame } from "../utils/firestore/createNewGame";
-
-// 前ページでuseHistoryでstateを渡している。stateがundefinedのときは404ページに遷移するようにすれば、url直入力で入れなくさせられるはず。
-
-type State = {
-  userName: string;
-  roomId: string;
-};
+import { getObjFromLocalStorage } from "../utils/getObjFromLocalStorage";
+import { browserBackProtection } from "../utils/browserBackProtection";
 
 export const HostEntrance: VFC = () => {
-  const location = useLocation<State>();
-  const { userName, roomId } = location.state
-    ? location.state
-    : window.history.state;
+  const { userName, roomId } = getObjFromLocalStorage("userInfo");
   const [usersName, setUsersName] = useState([userName]);
-  console.log(location.state);
-  // console.log(window.history.state);
-  const storageRoomId = localStorage.getItem("roomId");
-  console.log(storageRoomId);
 
   useEffect(() => {
-    window.history.pushState(location.state, "", null);
+    browserBackProtection();
     return onSnapshot(doc(db, `hgs/v1/rooms/${roomId}`), (doc) => {
       const data = doc.data();
       if (data) {
@@ -39,7 +27,7 @@ export const HostEntrance: VFC = () => {
         console.log("changed");
       }
     });
-  }, [location.state, roomId]);
+  }, [roomId]);
 
   const history = useHistory();
   const { isOpen, openModal, closeModal } = useModals();
@@ -57,6 +45,7 @@ export const HostEntrance: VFC = () => {
 
   const cancelGame = () => {
     console.log("Cancel the game");
+    localStorage.clear();
     history.push("/");
   };
 

--- a/src/utils/browserBackProtection.ts
+++ b/src/utils/browserBackProtection.ts
@@ -1,0 +1,7 @@
+// ブラウザバックを防止する関数
+export const browserBackProtection = () => {
+  window.history.pushState(null, "", null);
+  window.addEventListener("popstate", () => {
+    window.history.pushState(null, "", null);
+  });
+};

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -11,5 +11,8 @@ export const createNewRoom = async (name: string) => {
     isDuringGame: false,
   });
   await setDoc(usersRef, { displayName: name, isHost: true });
-  return roomsRef.id;
+  return {
+    roomId: roomsRef.id,
+    userId: usersRef.id,
+  };
 };

--- a/src/utils/getObjFromLocalStorage.ts
+++ b/src/utils/getObjFromLocalStorage.ts
@@ -1,0 +1,7 @@
+// ローカルストレージからJSONを取得する関数
+export const getObjFromLocalStorage = (key: string) => {
+  const getItem = localStorage.getItem(key);
+  if (typeof getItem === "string") {
+    return JSON.parse(getItem);
+  }
+};


### PR DESCRIPTION
ブラウザバックの対策で初回レンダリング時とブラウザバック時にダミーのセッション履歴を作成することで、ブラウザバックを実質無効化。
上記処理を挟むとuseLocationのstateが失われるため、localStorageで必要な情報を保存・取得するように変更。