### PR TITLE
フロントのみの実装だった箇所にデータのやりとりを追加＋リファクタ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react-modal": "^3.13.1",
         "@types/react-router-dom": "^5.3.0",
         "antd": "^4.16.13",
+        "browser-image-compression": "^1.0.17",
         "firebase": "^9.1.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -5711,6 +5712,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "node_modules/browser-image-compression": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-1.0.17.tgz",
+      "integrity": "sha512-TMDh3gyNlVA5Vvn0D0AdWr33s2ftIeokHK406z8cYlLJ4ANAq1x6eMaSzqedDoZwUGyTVB+0rhNVaSFgM3YAZg==",
+      "dependencies": {
+        "core-js": "^3.16.1",
+        "uzip": "0.20201231.0"
+      }
+    },
+    "node_modules/browser-image-compression/node_modules/core-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
+      "integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -21304,6 +21324,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -27558,6 +27583,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-image-compression": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-1.0.17.tgz",
+      "integrity": "sha512-TMDh3gyNlVA5Vvn0D0AdWr33s2ftIeokHK406z8cYlLJ4ANAq1x6eMaSzqedDoZwUGyTVB+0rhNVaSFgM3YAZg==",
+      "requires": {
+        "core-js": "^3.16.1",
+        "uzip": "0.20201231.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.19.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
+          "integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g=="
+        }
+      }
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -39843,6 +39884,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "optional": true
+    },
+    "uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/react-modal": "^3.13.1",
     "@types/react-router-dom": "^5.3.0",
     "antd": "^4.16.13",
+    "browser-image-compression": "^1.0.17",
     "firebase": "^9.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -7,13 +7,13 @@ const { Option } = Select;
 
 type Props = {
   usersName: Array<string>;
-  actorNumber: number;
+  currentActorNumber: number;
   isFinished: boolean;
 };
 
 export const AnswersContent: VFC<Props> = ({
   usersName,
-  actorNumber,
+  currentActorNumber,
   isFinished,
 }) => {
   const [answer, setAnswer] = useState<string | null>(null);
@@ -127,7 +127,7 @@ export const AnswersContent: VFC<Props> = ({
               <ul>
                 {usersName.map((name, i) => {
                   let fontColor;
-                  if (i === actorNumber) fontColor = "text-vivid-red";
+                  if (i === currentActorNumber) fontColor = "text-vivid-red";
                   return (
                     <li key={name} className={`text-left ${fontColor}`}>
                       {name}

--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, VFC } from "react";
+import { useCallback, useEffect, useState, VFC } from "react";
 import { Select } from "antd";
 import { createAlphabetArray } from "../../utils/createArray";
 import { PrimaryButton } from "../Buttons";
@@ -13,6 +13,7 @@ type Props = {
   userId: string;
   usersName: Array<string>;
   userAlphabet: string;
+  userActorNumber: number | undefined;
   currentActorNumber: number;
   isFinished: boolean;
 };
@@ -22,11 +23,11 @@ export const AnswersContent: VFC<Props> = ({
   userId,
   usersName,
   userAlphabet,
+  userActorNumber,
   currentActorNumber,
   isFinished,
 }) => {
   const [answer, setAnswer] = useState<string | null>(null);
-  // firestoreに保存した回答から取得
   const [sentAnswers, setSentAnswers] = useState<Array<string>>([]);
 
   const allOptions = createAlphabetArray(usersName.length);
@@ -54,13 +55,22 @@ export const AnswersContent: VFC<Props> = ({
     setAnswer(value);
   };
 
-  const onClickSendButton = () => {
-    if (answer) {
-      sendAnswer(roomId, userId, answer);
-      setSentAnswers([...sentAnswers, answer]);
+  const onClickSendButton = (value: string | null) => {
+    if (value) {
+      sendAnswer(roomId, userId, value);
+      setSentAnswers([...sentAnswers, value]);
+      setAnswer(null);
     }
-    setAnswer(null);
   };
+
+  // if (
+  //   currentActorNumber === userActorNumber &&
+  //   sentAnswers.length < currentActorNumber
+  // ) {
+  //   sendAnswer(roomId, userId, "ー");
+  //   setSentAnswers([...sentAnswers, "ー"]);
+  //   console.log(1);
+  // }
 
   return (
     <>
@@ -130,27 +140,38 @@ export const AnswersContent: VFC<Props> = ({
             各アルファベットは1度しか選べません
           </p>
           {currentActorNumber === sentAnswers.length ? (
-            <div className="space-x-8 my-2">
-              <Select
-                onChange={handleChange}
-                size="large"
-                className="w-24 text-lg border-2"
-              >
-                {selectableOptions.map((option) => {
-                  return (
-                    <Option key={option} value={option}>
-                      {option}
-                    </Option>
-                  );
-                })}
-              </Select>
-              <PrimaryButton
-                text="送信"
-                onClick={onClickSendButton}
-                width={24}
-                height={10}
-              />
-            </div>
+            currentActorNumber === userActorNumber ? (
+              <div className="my-2">
+                <PrimaryButton
+                  text="演技しました"
+                  onClick={() => onClickSendButton("ー")}
+                  width={48}
+                  height={10}
+                ></PrimaryButton>
+              </div>
+            ) : (
+              <div className="space-x-8 my-2">
+                <Select
+                  onChange={handleChange}
+                  size="large"
+                  className="w-24 text-lg border-2"
+                >
+                  {selectableOptions.map((option) => {
+                    return (
+                      <Option key={option} value={option}>
+                        {option}
+                      </Option>
+                    );
+                  })}
+                </Select>
+                <PrimaryButton
+                  text="送信"
+                  onClick={() => onClickSendButton(answer)}
+                  width={24}
+                  height={10}
+                />
+              </div>
+            )
           ) : (
             <p className="text-lg my-4 text-blue-500">
               他の人の回答を待っています...

--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -35,6 +35,7 @@ export const AnswersContent: VFC<Props> = ({
   );
 
   useEffect(() => {
+    let unmount = false;
     const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
     (async () => {
       const fetchUser = async () => {
@@ -42,9 +43,11 @@ export const AnswersContent: VFC<Props> = ({
         return userSnapshot.data();
       };
       const userData = await fetchUser();
-      setSentAnswers(userData!.answers);
+      if (!unmount) setSentAnswers(userData!.answers);
     })();
-    return () => {};
+    return () => {
+      unmount = true;
+    };
   }, [roomId, userId]);
 
   const handleChange = (value: string) => {
@@ -126,27 +129,33 @@ export const AnswersContent: VFC<Props> = ({
             <br />
             各アルファベットは1度しか選べません
           </p>
-          <div className="space-x-8 my-2">
-            <Select
-              onChange={handleChange}
-              size="large"
-              className="w-24 text-lg border-2"
-            >
-              {selectableOptions.map((option) => {
-                return (
-                  <Option key={option} value={option}>
-                    {option}
-                  </Option>
-                );
-              })}
-            </Select>
-            <PrimaryButton
-              text="送信"
-              onClick={onClickSendButton}
-              width={24}
-              height={10}
-            />
-          </div>
+          {currentActorNumber === sentAnswers.length ? (
+            <div className="space-x-8 my-2">
+              <Select
+                onChange={handleChange}
+                size="large"
+                className="w-24 text-lg border-2"
+              >
+                {selectableOptions.map((option) => {
+                  return (
+                    <Option key={option} value={option}>
+                      {option}
+                    </Option>
+                  );
+                })}
+              </Select>
+              <PrimaryButton
+                text="送信"
+                onClick={onClickSendButton}
+                width={24}
+                height={10}
+              />
+            </div>
+          ) : (
+            <p className="text-lg my-4 text-blue-500">
+              他の人の回答を待っています...
+            </p>
+          )}
           <div className="text-lg flex justify-center space-x-4">
             <div>
               <p>順番</p>

--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -2,16 +2,21 @@ import { useState, VFC } from "react";
 import { Select } from "antd";
 import { createAlphabetArray } from "../../utils/createArray";
 import { PrimaryButton } from "../Buttons";
+import { sendAnswer } from "../../utils/firestore/sendAnswer";
 
 const { Option } = Select;
 
 type Props = {
+  roomId: string;
+  userId: string;
   usersName: Array<string>;
   currentActorNumber: number;
   isFinished: boolean;
 };
 
 export const AnswersContent: VFC<Props> = ({
+  roomId,
+  userId,
   usersName,
   currentActorNumber,
   isFinished,
@@ -30,7 +35,10 @@ export const AnswersContent: VFC<Props> = ({
   };
 
   const onClickSendButton = () => {
-    console.log(`send ${answer}`);
+    if (answer) {
+      sendAnswer(roomId, userId, answer);
+    }
+    setAnswer(null);
   };
 
   return (

--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -1,77 +1,34 @@
-import { useCallback, useEffect, useState, VFC } from "react";
+import { VFC } from "react";
 import { Select } from "antd";
-import { createAlphabetArray } from "../../utils/createArray";
 import { PrimaryButton } from "../Buttons";
-import { sendAnswer } from "../../utils/firestore/sendAnswer";
-import { doc, getDoc } from "@firebase/firestore";
-import { db } from "../../service/firebase";
 
 const { Option } = Select;
 
 type Props = {
-  roomId: string;
-  userId: string;
   usersName: Array<string>;
-  userAlphabet: string;
   userActorNumber: number | undefined;
   currentActorNumber: number;
   isFinished: boolean;
+  answer: string | null;
+  sentAnswers: Array<string>;
+  allAnswers: Array<Array<string>>;
+  selectableOptions: Array<string>;
+  onClickSendButton: (value: string | null) => void;
+  selectAlphabet: (value: string) => void;
 };
 
 export const AnswersContent: VFC<Props> = ({
-  roomId,
-  userId,
   usersName,
-  userAlphabet,
   userActorNumber,
   currentActorNumber,
   isFinished,
+  answer,
+  sentAnswers,
+  allAnswers,
+  selectableOptions,
+  onClickSendButton,
+  selectAlphabet,
 }) => {
-  const [answer, setAnswer] = useState<string | null>(null);
-  const [sentAnswers, setSentAnswers] = useState<Array<string>>([]);
-
-  const allOptions = createAlphabetArray(usersName.length);
-  const selectableOptions = allOptions.filter(
-    (i) => sentAnswers.indexOf(i) === -1 && i !== userAlphabet
-  );
-
-  useEffect(() => {
-    let unmount = false;
-    const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
-    (async () => {
-      const fetchUser = async () => {
-        const userSnapshot = await getDoc(userRef);
-        return userSnapshot.data();
-      };
-      const userData = await fetchUser();
-      if (!unmount) setSentAnswers(userData!.answers);
-    })();
-    return () => {
-      unmount = true;
-    };
-  }, [roomId, userId]);
-
-  const handleChange = (value: string) => {
-    setAnswer(value);
-  };
-
-  const onClickSendButton = (value: string | null) => {
-    if (value) {
-      sendAnswer(roomId, userId, value);
-      setSentAnswers([...sentAnswers, value]);
-      setAnswer(null);
-    }
-  };
-
-  // if (
-  //   currentActorNumber === userActorNumber &&
-  //   sentAnswers.length < currentActorNumber
-  // ) {
-  //   sendAnswer(roomId, userId, "ー");
-  //   setSentAnswers([...sentAnswers, "ー"]);
-  //   console.log(1);
-  // }
-
   return (
     <>
       {isFinished ? (
@@ -112,20 +69,17 @@ export const AnswersContent: VFC<Props> = ({
                     >
                       {name}
                     </th>
-                    {["A", "B", "C", "D", "E", "F", "G", "H"].map(
-                      (alphabet, i) => {
-                        const bgColor =
-                          i % 2 === 1 ? "bg-white" : "bg-gray-100";
-                        return (
-                          <td
-                            key={alphabet}
-                            className={`text-center border-2 h-6v writing-mode-horizontal ${bgColor}`}
-                          >
-                            {alphabet}
-                          </td>
-                        );
-                      }
-                    )}
+                    {sentAnswers.map((alphabet, i) => {
+                      const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
+                      return (
+                        <td
+                          key={alphabet}
+                          className={`text-center border-2 h-6v writing-mode-horizontal ${bgColor}`}
+                        >
+                          {alphabet}
+                        </td>
+                      );
+                    })}
                   </tr>
                 );
               })}
@@ -152,7 +106,7 @@ export const AnswersContent: VFC<Props> = ({
             ) : (
               <div className="space-x-8 my-2">
                 <Select
-                  onChange={handleChange}
+                  onChange={selectAlphabet}
                   size="large"
                   className="w-24 text-lg border-2"
                 >

--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -1,6 +1,6 @@
 import { useState, VFC } from "react";
 import { Select } from "antd";
-import { createAlphabetArray } from "../../utils/createAlphabetArray";
+import { createAlphabetArray } from "../../utils/createArray";
 import { PrimaryButton } from "../Buttons";
 
 const { Option } = Select;

--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -44,6 +44,7 @@ export const AnswersContent: VFC<Props> = ({
       const userData = await fetchUser();
       setSentAnswers(userData!.answers);
     })();
+    return () => {};
   }, [roomId, userId]);
 
   const handleChange = (value: string) => {
@@ -53,6 +54,7 @@ export const AnswersContent: VFC<Props> = ({
   const onClickSendButton = () => {
     if (answer) {
       sendAnswer(roomId, userId, answer);
+      setSentAnswers([...sentAnswers, answer]);
     }
     setAnswer(null);
   };

--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -60,7 +60,7 @@ export const AnswersContent: VFC<Props> = ({
               </tr>
             </thead>
             <tbody>
-              {usersName.map((name) => {
+              {usersName.map((name, i) => {
                 const fontSize = name.length <= 5 ? "text-sm" : "text-xs";
                 return (
                   <tr key={name}>
@@ -69,7 +69,7 @@ export const AnswersContent: VFC<Props> = ({
                     >
                       {name}
                     </th>
-                    {sentAnswers.map((alphabet, i) => {
+                    {allAnswers[i].map((alphabet, i) => {
                       const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
                       return (
                         <td

--- a/src/components/contents/ThemeContent.tsx
+++ b/src/components/contents/ThemeContent.tsx
@@ -1,21 +1,10 @@
-import { doc, getDoc } from "@firebase/firestore";
-import { useEffect, useState, VFC } from "react";
-import { db } from "../../service/firebase";
+import { VFC } from "react";
 
 type Props = {
-  roomId: string;
+  themeImg: string;
 };
 
-export const ThemeContent: VFC<Props> = ({ roomId }) => {
-  const [themeImg, setThemeImg] = useState("");
-  useEffect(() => {
-    const getImg = async () => {
-      const roomDoc = await getDoc(doc(db, `hgs/v1/rooms/${roomId}`));
-      const getImage = roomDoc.data()!.themeImg;
-      setThemeImg(getImage);
-    };
-    getImg();
-  }, [roomId]);
+export const ThemeContent: VFC<Props> = ({ themeImg }) => {
   return (
     <img
       className="max-h-60v max-w-full mx-auto mt-3"

--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -19,7 +19,7 @@ export const CreateRoom: VFC = () => {
     try {
       const ids = await createNewRoom(userName);
       const userInfo = { ...ids, userName };
-      localStorage.setItem("userInfo", JSON.stringify(userInfo));
+      sessionStorage.setItem("userInfo", JSON.stringify(userInfo));
       history.push("/host-entrance");
     } catch (e) {
       console.log(e);

--- a/src/pages/EnterRoom.tsx
+++ b/src/pages/EnterRoom.tsx
@@ -39,7 +39,7 @@ export const EnterRoom: VFC = () => {
     try {
       const userId = await addGuestUser(roomId, userName);
       const userInfo = { roomId, userId, userName };
-      localStorage.setItem("userInfo", JSON.stringify(userInfo));
+      sessionStorage.setItem("userInfo", JSON.stringify(userInfo));
       history.push(`/guest-entrance`);
     } catch (e) {
       console.log(e);

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -88,19 +88,20 @@ export const Game = () => {
       }
     })();
 
+    const snapshot = onSnapshot(usersRef, (snapshot) => {
+      const answersLength: Array<number> = [];
+      snapshot.forEach((doc) => {
+        answersLength.push(doc.data().answers.length);
+      });
+      const min = answersLength.reduce((a, b) => {
+        return Math.min(a, b);
+      });
+      setCurrentActorNumber(min);
+      console.log("snapshot");
+    });
     return () => {
       unmount = true;
-      onSnapshot(usersRef, (snapshot) => {
-        const answersLength: Array<number> = [];
-        snapshot.forEach((doc) => {
-          answersLength.push(doc.data().answers.length);
-        });
-        const min = answersLength.reduce((a, b) => {
-          return Math.min(a, b);
-        });
-        setCurrentActorNumber(min);
-        console.log("snapshot");
-      });
+      snapshot();
     };
   }, [roomId, userId]);
 

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -29,6 +29,7 @@ export const Game = () => {
   const [usersName, setUsersName] = useState<Array<string>>([]);
   const [userAlphabet, setUserAlphabet] = useState("");
   const [currentActorNumber, setCurrentActorNumber] = useState(0);
+  const [themeImg, setThemeImg] = useState("");
 
   useEffect(() => {
     browserBackProtection();
@@ -54,10 +55,13 @@ export const Game = () => {
       };
 
       const roomData = await fetchRoom();
-      const correctAnswer = roomData!.correctAnswer as string[];
+      const correctAnswer: string[] = roomData!.correctAnswer;
       const userData = await fetchUser();
       const actOrder = userData!.actOrder;
       setUserAlphabet(correctAnswer[actOrder]);
+
+      const getImage: string = roomData!.themeImg;
+      setThemeImg(getImage);
 
       const allUsersData = await orderByAllUsers();
       const allUsersName = allUsersData.map((data) => {
@@ -117,7 +121,7 @@ export const Game = () => {
         onClickAnswers={onClickAnswers}
         onClickPoints={onClickPoints}
       />
-      {activeTab === "theme" && <ThemeContent roomId={roomId} />}
+      {activeTab === "theme" && <ThemeContent themeImg={themeImg} />}
       {activeTab === "answers" && (
         <AnswersContent
           roomId={roomId}

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -28,6 +28,7 @@ export const Game = () => {
   const [userAlphabet, setUserAlphabet] = useState("");
 
   useEffect(() => {
+    // TODO:firestoreとのやりとりを隠蔽する
     (async () => {
       const fetchRoom = async () => {
         const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
@@ -63,14 +64,7 @@ export const Game = () => {
       setUsersName(allUsersName);
     })();
   }, []);
-  // TODO:firestoreとのやりとりを隠匿する
-
-  // const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
-  // const userSnapshot = await getDoc(userRef);
-  // const userData = userSnapshot.data();
-
   const [actorNumber, setActorNumber] = useState(0);
-  // firestoreから取得（演技順をfirestoreに登録する必要あり？）
 
   const isFinished = actorNumber === usersName.length;
 

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -28,6 +28,7 @@ export const Game = () => {
     getObjFromSessionStorage("userInfo");
   const [usersName, setUsersName] = useState<Array<string>>([]);
   const [userAlphabet, setUserAlphabet] = useState("");
+  const [userActorNumber, setUserActorNumber] = useState<number>();
   const [currentActorNumber, setCurrentActorNumber] = useState(0);
   const [themeImg, setThemeImg] = useState("");
 
@@ -58,6 +59,7 @@ export const Game = () => {
       const correctAnswer: string[] = roomData!.correctAnswer;
       const userData = await fetchUser();
       const actOrder = userData!.actOrder;
+      setUserActorNumber(actOrder);
       setUserAlphabet(correctAnswer[actOrder]);
 
       const getImage: string = roomData!.themeImg;
@@ -128,6 +130,7 @@ export const Game = () => {
           userId={userId}
           usersName={usersName}
           userAlphabet={userAlphabet}
+          userActorNumber={userActorNumber}
           currentActorNumber={currentActorNumber}
           isFinished={isFinished}
         />

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -64,9 +64,9 @@ export const Game = () => {
       setUsersName(allUsersName);
     })();
   }, []);
-  const [actorNumber, setActorNumber] = useState(0);
+  const [currentActorNumber, setCurrentActorNumber] = useState(0);
 
-  const isFinished = actorNumber === usersName.length;
+  const isFinished = currentActorNumber === usersName.length;
 
   type Tab = "theme" | "answers" | "points";
   const [activeTab, setActiveTab] = useState<Tab>("theme");
@@ -95,7 +95,8 @@ export const Game = () => {
         </p>
       ) : (
         <p className="h-10v flex text-xl justify-center items-center text-vivid-red">
-          {actorNumber + 1}人目の演者は{usersName[actorNumber]}さん
+          {currentActorNumber + 1}人目の演者は{usersName[currentActorNumber]}
+          さん
         </p>
       )}
       <GameTabs
@@ -108,7 +109,7 @@ export const Game = () => {
       {activeTab === "answers" && (
         <AnswersContent
           usersName={usersName}
-          actorNumber={actorNumber}
+          currentActorNumber={currentActorNumber}
           isFinished={isFinished}
         />
       )}

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -123,6 +123,7 @@ export const Game = () => {
           roomId={roomId}
           userId={userId}
           usersName={usersName}
+          userAlphabet={userAlphabet}
           currentActorNumber={currentActorNumber}
           isFinished={isFinished}
         />

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -4,26 +4,48 @@ import { Information } from "../components/Information";
 import { ThemeContent } from "../components/contents/ThemeContent";
 import { AnswersContent } from "../components/contents/AnswersContent";
 import { PointsContent } from "../components/contents/PointsContent";
-import { getObjFromLocalStorage } from "../utils/getObjFromLocalStorage";
+import { getObjFromSessionStorage } from "../utils/getObjFromSessionStorage";
+import { collection, doc, getDoc, getDocs } from "@firebase/firestore";
+import { db } from "../service/firebase";
 
 export const Game = () => {
-  const { userName, roomId, userId } = getObjFromLocalStorage("userInfo");
-  const userAlphabet = "A";
+  const { userName, roomId, userId } = getObjFromSessionStorage("userInfo");
+  // TODO:firestoreとのやりとりを隠匿する
+  const fetchRoom = async () => {
+    const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
+    const roomSnapshot = await getDoc(roomRef);
+    return roomSnapshot.data();
+  };
+  const roomData = fetchRoom();
 
-  const [actorNumber, setActorNumber] = useState(8);
+  const fetchAllUsers = async () => {
+    const usersCollection = collection(db, `hgs/v1/rooms/${roomId}/users`);
+    const usersSnapshot = await getDocs(usersCollection);
+    return usersSnapshot.docs.map((doc) => {
+      return doc.data();
+    });
+  };
+  console.log(fetchAllUsers());
+  // const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
+  // const userSnapshot = await getDoc(userRef);
+  // const userData = userSnapshot.data();
+
+  const [actorNumber, setActorNumber] = useState(0);
   // firestoreから取得（演技順をfirestoreに登録する必要あり？）
-  const usersName = [
-    "ドナルド",
-    "スティーブ",
-    "太郎",
-    "炭治郎",
-    "優柔ふだ子",
-    "マイケル",
-    "ジョブズ",
-    "ミーナミーナ",
-  ];
+  const usersName = ["a"];
+  const userAlphabet = "a";
 
   const isFinished = actorNumber === usersName.length;
+
+  // (async () => {
+  //   const usersRef = collection(db, `hgs/v1/rooms/${roomId}/users`);
+  //   const usersDoc = await getDocs(usersRef);
+  //   const usersOrder = new Array(usersDoc.size)
+  //   usersDoc.forEach((userDoc) => {
+  //     const actOrder = userDoc.data().actOrder as number
+  //     usersOrder[actOrder] =
+  //   })
+  // })();
 
   type Tab = "theme" | "answers" | "points";
   const [activeTab, setActiveTab] = useState<Tab>("theme");

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,51 +1,78 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { GameTabs } from "../components/GameTabs";
 import { Information } from "../components/Information";
 import { ThemeContent } from "../components/contents/ThemeContent";
 import { AnswersContent } from "../components/contents/AnswersContent";
 import { PointsContent } from "../components/contents/PointsContent";
 import { getObjFromSessionStorage } from "../utils/getObjFromSessionStorage";
-import { collection, doc, getDoc, getDocs } from "@firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  orderBy,
+  query,
+} from "@firebase/firestore";
 import { db } from "../service/firebase";
 
-export const Game = () => {
-  const { userName, roomId, userId } = getObjFromSessionStorage("userInfo");
-  // TODO:firestoreとのやりとりを隠匿する
-  const fetchRoom = async () => {
-    const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
-    const roomSnapshot = await getDoc(roomRef);
-    return roomSnapshot.data();
-  };
-  const roomData = fetchRoom();
+type Type = {
+  userName: string;
+  roomId: string;
+  userId: string;
+};
 
-  const fetchAllUsers = async () => {
-    const usersCollection = collection(db, `hgs/v1/rooms/${roomId}/users`);
-    const usersSnapshot = await getDocs(usersCollection);
-    return usersSnapshot.docs.map((doc) => {
-      return doc.data();
-    });
-  };
-  console.log(fetchAllUsers());
+export const Game = () => {
+  const { userName, roomId, userId }: Type =
+    getObjFromSessionStorage("userInfo");
+  const [usersName, setUsersName] = useState<Array<string>>([]);
+  const [userAlphabet, setUserAlphabet] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      const fetchRoom = async () => {
+        const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
+        const roomSnapshot = await getDoc(roomRef);
+        return roomSnapshot.data();
+      };
+      const fetchUser = async () => {
+        const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
+        const userSnapshot = await getDoc(userRef);
+        return userSnapshot.data();
+      };
+      const orderByAllUsers = async () => {
+        const usersQuery = query(
+          collection(db, `hgs/v1/rooms/${roomId}/users`),
+          orderBy("actOrder")
+        );
+        const usersSnapshot = await getDocs(usersQuery);
+        return usersSnapshot.docs.map((doc) => {
+          return doc.data();
+        });
+      };
+
+      const roomData = await fetchRoom();
+      const correctAnswer = roomData!.correctAnswer as string[];
+      const userData = await fetchUser();
+      const actOrder = userData!.actOrder;
+      setUserAlphabet(correctAnswer[actOrder]);
+
+      const allUsersData = await orderByAllUsers();
+      const allUsersName = allUsersData.map((data) => {
+        return data.displayName as string;
+      });
+      setUsersName(allUsersName);
+    })();
+  }, []);
+  // TODO:firestoreとのやりとりを隠匿する
+
   // const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
   // const userSnapshot = await getDoc(userRef);
   // const userData = userSnapshot.data();
 
   const [actorNumber, setActorNumber] = useState(0);
   // firestoreから取得（演技順をfirestoreに登録する必要あり？）
-  const usersName = ["a"];
-  const userAlphabet = "a";
 
   const isFinished = actorNumber === usersName.length;
-
-  // (async () => {
-  //   const usersRef = collection(db, `hgs/v1/rooms/${roomId}/users`);
-  //   const usersDoc = await getDocs(usersRef);
-  //   const usersOrder = new Array(usersDoc.size)
-  //   usersDoc.forEach((userDoc) => {
-  //     const actOrder = userDoc.data().actOrder as number
-  //     usersOrder[actOrder] =
-  //   })
-  // })();
 
   type Tab = "theme" | "answers" | "points";
   const [activeTab, setActiveTab] = useState<Tab>("theme");

--- a/src/pages/GuestEntrance.tsx
+++ b/src/pages/GuestEntrance.tsx
@@ -6,11 +6,11 @@ import { Information } from "../components/Information";
 import { removeUser } from "../utils/firestore/removeUser";
 import { doc, onSnapshot } from "@firebase/firestore";
 import { db } from "../service/firebase";
-import { getObjFromLocalStorage } from "../utils/getObjFromLocalStorage";
+import { getObjFromSessionStorage } from "../utils/getObjFromSessionStorage";
 import { browserBackProtection } from "../utils/browserBackProtection";
 
 export const GuestEntrance: VFC = () => {
-  const { userName, roomId, userId } = getObjFromLocalStorage("userInfo");
+  const { userName, roomId, userId } = getObjFromSessionStorage("userInfo");
   const [isOpen, setIsOpen] = useState(false);
   const history = useHistory();
 
@@ -23,7 +23,7 @@ export const GuestEntrance: VFC = () => {
 
   const returnToTopPage = () => {
     removeUser(roomId, userName, userId);
-    localStorage.clear();
+    sessionStorage.clear();
     history.push("/");
   };
 

--- a/src/pages/HostEntrance.tsx
+++ b/src/pages/HostEntrance.tsx
@@ -70,7 +70,7 @@ export const HostEntrance: VFC = () => {
 
   const onFileChange = useCallback(async ({ fileList: newFileList }) => {
     const options = {
-      maxSizeMB: 1,
+      maxSizeMB: 0.7,
       maxWidthOrHeight: 1920,
     };
     try {

--- a/src/pages/HostEntrance.tsx
+++ b/src/pages/HostEntrance.tsx
@@ -12,11 +12,11 @@ import { useModals } from "../hooks/useModals";
 import { doc, onSnapshot } from "@firebase/firestore";
 import { db } from "../service/firebase";
 import { createNewGame } from "../utils/firestore/createNewGame";
-import { getObjFromLocalStorage } from "../utils/getObjFromLocalStorage";
+import { getObjFromSessionStorage } from "../utils/getObjFromSessionStorage";
 import { browserBackProtection } from "../utils/browserBackProtection";
 
 export const HostEntrance: VFC = () => {
-  const { userName, roomId } = getObjFromLocalStorage("userInfo");
+  const { userName, roomId } = getObjFromSessionStorage("userInfo");
   const [usersName, setUsersName] = useState([userName]);
   const [fileList, setFileList] = useState<UploadFile<any>[]>([]);
   const [preview, setPreview] = useState(false);
@@ -50,7 +50,7 @@ export const HostEntrance: VFC = () => {
 
   const cancelGame = () => {
     console.log("Cancel the game");
-    localStorage.clear();
+    sessionStorage.clear();
     history.push("/");
   };
 

--- a/src/pages/HostEntrance.tsx
+++ b/src/pages/HostEntrance.tsx
@@ -14,6 +14,7 @@ import { db } from "../service/firebase";
 import { createNewGame } from "../utils/firestore/createNewGame";
 import { getObjFromSessionStorage } from "../utils/getObjFromSessionStorage";
 import { browserBackProtection } from "../utils/browserBackProtection";
+import imageCompression from "browser-image-compression";
 
 export const HostEntrance: VFC = () => {
   const { userName, roomId } = getObjFromSessionStorage("userInfo");
@@ -68,15 +69,21 @@ export const HostEntrance: VFC = () => {
   };
 
   const onFileChange = useCallback(async ({ fileList: newFileList }) => {
-    setFileList(newFileList);
-    if (newFileList[0]) {
-      const src = await new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.readAsDataURL(newFileList[0].originFileObj!);
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = (error) => reject(error);
-      });
+    const options = {
+      maxSizeMB: 1,
+      maxWidthOrHeight: 1920,
+    };
+    try {
+      setFileList(newFileList);
+      const compressedImage = await imageCompression(
+        newFileList[0].originFileObj,
+        options
+      );
+      const src = await imageCompression.getDataUrlFromFile(compressedImage);
       setUploadImg(src as string);
+    } catch (error) {
+      console.error(error);
+      throw error;
     }
   }, []);
 

--- a/src/utils/createArray.ts
+++ b/src/utils/createArray.ts
@@ -6,3 +6,11 @@ export const createAlphabetArray = (number: number) => {
   }
   return alphabets;
 };
+
+export const createNumberArray = (number: number) => {
+  let numbers = [];
+  for (let i = 0; i < number; i++) {
+    numbers.push(i);
+  }
+  return numbers;
+};

--- a/src/utils/firestore/addGuestUser.ts
+++ b/src/utils/firestore/addGuestUser.ts
@@ -15,7 +15,6 @@ export const addGuestUser = async (roomId: string, userName: string) => {
   await setDoc(usersRef, {
     displayName: userName,
     isHost: false,
-    userTheme: "",
     actOrder: null,
     actScore: null,
     answerScore: null,

--- a/src/utils/firestore/addGuestUser.ts
+++ b/src/utils/firestore/addGuestUser.ts
@@ -12,6 +12,13 @@ export const addGuestUser = async (roomId: string, userName: string) => {
   const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
   await updateDoc(roomRef, { usersName: arrayUnion(userName) });
   const usersRef = doc(collection(db, `hgs/v1/rooms/${roomId}/users`));
-  await setDoc(usersRef, { displayName: userName, isHost: false });
+  await setDoc(usersRef, {
+    displayName: userName,
+    isHost: false,
+    userTheme: "",
+    actOrder: null,
+    actScore: null,
+    answerScore: null,
+  });
   return usersRef.id;
 };

--- a/src/utils/firestore/addGuestUser.ts
+++ b/src/utils/firestore/addGuestUser.ts
@@ -16,6 +16,7 @@ export const addGuestUser = async (roomId: string, userName: string) => {
     displayName: userName,
     isHost: false,
     actOrder: null,
+    answers: [],
     actScore: null,
     answerScore: null,
   });

--- a/src/utils/firestore/createNewGame.ts
+++ b/src/utils/firestore/createNewGame.ts
@@ -1,6 +1,6 @@
 import { collection, doc, getDocs, runTransaction } from "@firebase/firestore";
 import { db } from "../../service/firebase";
-import { createAlphabetArray } from "../createAlphabetArray";
+import { createAlphabetArray, createNumberArray } from "../createArray";
 import { shuffleArray } from "../shuffleArray";
 
 export const createNewGame = async (roomId: string, uploadImg: string) => {
@@ -10,6 +10,9 @@ export const createNewGame = async (roomId: string, uploadImg: string) => {
   const alphabetArray: Array<string> = shuffleArray(
     createAlphabetArray(usersDoc.size)
   );
+  const numberArray: Array<string> = shuffleArray(
+    createNumberArray(usersDoc.size)
+  );
 
   try {
     await runTransaction(db, async (transaction) => {
@@ -17,6 +20,7 @@ export const createNewGame = async (roomId: string, uploadImg: string) => {
       if (!roomDoc.exists()) {
         throw new Error("Document does not exist!");
       }
+
       const newGameCount: number = roomDoc.data().gameCount + 1;
       transaction.update(roomRef, {
         gameCount: newGameCount,
@@ -30,7 +34,12 @@ export const createNewGame = async (roomId: string, uploadImg: string) => {
           `hgs/v1/rooms/${roomId}/users/${userDoc.id}/games/${gameId}`
         );
         const alphabet = alphabetArray.shift();
-        transaction.set(gameRef, { userTheme: alphabet, answers: [] });
+        const number = numberArray.shift();
+        transaction.set(gameRef, {
+          userTheme: alphabet,
+          actNumber: number,
+          answers: [],
+        });
       });
     });
     console.log("Transaction successfully committed!");

--- a/src/utils/firestore/createNewGame.ts
+++ b/src/utils/firestore/createNewGame.ts
@@ -1,5 +1,4 @@
 import { collection, doc, getDocs, runTransaction } from "@firebase/firestore";
-import { error } from "console";
 import { db } from "../../service/firebase";
 import { createAlphabetArray, createNumberArray } from "../createArray";
 import { shuffleArray } from "../shuffleArray";

--- a/src/utils/firestore/createNewGame.ts
+++ b/src/utils/firestore/createNewGame.ts
@@ -27,18 +27,14 @@ export const createNewGame = async (roomId: string, uploadImg: string) => {
         isDuringGame: true,
         themeImg: uploadImg,
       });
-      const gameId = `game${newGameCount}`;
+
       usersDoc.forEach((userDoc) => {
-        const gameRef = doc(
-          db,
-          `hgs/v1/rooms/${roomId}/users/${userDoc.id}/games/${gameId}`
-        );
+        const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userDoc.id}`);
         const alphabet = alphabetArray.shift();
         const number = numberArray.shift();
-        transaction.set(gameRef, {
+        transaction.update(userRef, {
           userTheme: alphabet,
-          actNumber: number,
-          answers: [],
+          actOrder: number,
         });
       });
     });

--- a/src/utils/firestore/createNewGame.ts
+++ b/src/utils/firestore/createNewGame.ts
@@ -26,14 +26,13 @@ export const createNewGame = async (roomId: string, uploadImg: string) => {
         gameCount: newGameCount,
         isDuringGame: true,
         themeImg: uploadImg,
+        correctAnswer: alphabetArray,
       });
 
       usersDoc.forEach((userDoc) => {
         const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userDoc.id}`);
-        const alphabet = alphabetArray.shift();
         const number = numberArray.shift();
         transaction.update(userRef, {
-          userTheme: alphabet,
           actOrder: number,
         });
       });

--- a/src/utils/firestore/createNewGame.ts
+++ b/src/utils/firestore/createNewGame.ts
@@ -1,4 +1,5 @@
 import { collection, doc, getDocs, runTransaction } from "@firebase/firestore";
+import { error } from "console";
 import { db } from "../../service/firebase";
 import { createAlphabetArray, createNumberArray } from "../createArray";
 import { shuffleArray } from "../shuffleArray";
@@ -38,7 +39,8 @@ export const createNewGame = async (roomId: string, uploadImg: string) => {
       });
     });
     console.log("Transaction successfully committed!");
-  } catch (e) {
-    console.log("Transaction failed: ", e);
+  } catch (error) {
+    console.log("Transaction failed: ", error);
+    throw new Error("ゲーム作成失敗");
   }
 };

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -14,7 +14,6 @@ export const createNewRoom = async (name: string) => {
   await setDoc(usersRef, {
     displayName: name,
     isHost: true,
-    userTheme: "",
     actOrder: null,
     actScore: null,
     answerScore: null,

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -15,6 +15,7 @@ export const createNewRoom = async (name: string) => {
     displayName: name,
     isHost: true,
     actOrder: null,
+    answers: [],
     actScore: null,
     answerScore: null,
   });

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -10,6 +10,7 @@ export const createNewRoom = async (name: string) => {
     gameCount: 0,
     isDuringGame: false,
     themeImg: "",
+    correctAnswer: [],
   });
   await setDoc(usersRef, {
     displayName: name,

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -11,7 +11,14 @@ export const createNewRoom = async (name: string) => {
     isDuringGame: false,
     themeImg: "",
   });
-  await setDoc(usersRef, { displayName: name, isHost: true });
+  await setDoc(usersRef, {
+    displayName: name,
+    isHost: true,
+    userTheme: "",
+    actOrder: null,
+    actScore: null,
+    answerScore: null,
+  });
   return {
     roomId: roomsRef.id,
     userId: usersRef.id,

--- a/src/utils/firestore/sendAnswer.ts
+++ b/src/utils/firestore/sendAnswer.ts
@@ -1,0 +1,14 @@
+import { arrayUnion, doc, updateDoc } from "@firebase/firestore";
+import { db } from "../../service/firebase";
+
+export const sendAnswer = async (
+  roomId: string,
+  userId: string,
+  answer: string
+) => {
+  const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
+  await updateDoc(userRef, {
+    answers: arrayUnion(answer),
+  });
+  console.log("send answer");
+};

--- a/src/utils/getObjFromSessionStorage.ts
+++ b/src/utils/getObjFromSessionStorage.ts
@@ -1,6 +1,6 @@
 // ローカルストレージからJSONを取得する関数
-export const getObjFromLocalStorage = (key: string) => {
-  const getItem = localStorage.getItem(key);
+export const getObjFromSessionStorage = (key: string) => {
+  const getItem = sessionStorage.getItem(key);
   if (typeof getItem === "string") {
     return JSON.parse(getItem);
   }


### PR DESCRIPTION
## やったこと
- Firestoreのデータ構造を変更
  - Gameコレクションを削除してRoomコレクションで管理
- 画像をリサイズしてからアップロードするように変更
- ゲームページにFirestoreとの通信を実装
- localStorageからsessionStorageに変更（動作確認のしやすさを考慮）
- GameページでのFirestoreへの回答送信とデータ取得を実装
- 他のユーザーが回答を終えるまでボタンを表示しないように変更
- 自分が演技するときはボタンの表示を別のものに変更
- リファクタリング
  - useEffectのメモリリークする可能性のある箇所を修正
  - stateや関数を親コンポーネントで管理など