### PR TITLE
回答集計と点数計算のロジック実装、スタイルの修正

### DIFF
--- a/src/components/contents/AnswersContent.tsx
+++ b/src/components/contents/AnswersContent.tsx
@@ -32,25 +32,27 @@ export const AnswersContent: VFC<Props> = ({
   return (
     <>
       {isFinished ? (
-        <div className="w-9/10 overflow-x-scroll mx-auto mt-2">
-          <table className="table-fixed bg-white border-2 whitespace-nowrap writing-mode-vertical-lr">
+        <div className="w-9/10 max-w-screen-sm overflow-x-auto mx-auto mt-2 ">
+          <table
+            className={`w-${
+              usersName.length * 12
+            } h-60v table-fixed text-center mx-auto`}
+          >
             <thead>
-              <tr>
-                <th className="w-20 h-6v text-lg font-thin sticky left-0 z-10 bg-gray-400 text-white">
-                  <span className="text-xs absolute top-0 right-0 writing-mode-horizontal">
-                    回答者
-                  </span>
-                  /
-                  <span className="pl-1 text-xs absolute bottom-0 left-0 writing-mode-horizontal">
+              <tr className="h-6v">
+                <th className="w-24 font-thin sticky left-0 z-10 bg-gray-400 text-white">
+                  <span className="text-xs absolute top-0 right-0">回答者</span>
+                  \
+                  <span className="pl-1 text-xs absolute bottom-0 left-0">
                     演技
                   </span>
                 </th>
                 {usersName.map((name, i) => {
                   const fontSize = name.length <= 5 ? "text-sm" : "text-xs";
-                  const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
+                  const bgColor = i % 2 === 1 ? "bg-gray-100" : "bg-white";
                   return (
                     <th
-                      className={`border-2 h-6v writing-mode-horizontal sticky left-0 z-10 ${fontSize} ${bgColor}`}
+                      className={`border-2 w-20 ${fontSize} ${bgColor}`}
                       key={name}
                     >
                       {name}
@@ -65,16 +67,16 @@ export const AnswersContent: VFC<Props> = ({
                 return (
                   <tr key={name}>
                     <th
-                      className={`w-20 border-2 h-6v writing-mode-horizontal ${fontSize}`}
+                      className={`w-20 border-2 sticky left-0 ${fontSize} bg-gray-100`}
                     >
                       {name}
                     </th>
                     {allAnswers[i].map((alphabet, i) => {
-                      const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
+                      const bgColor = i % 2 === 1 ? "bg-gray-100" : "bg-white";
                       return (
                         <td
                           key={alphabet}
-                          className={`text-center border-2 h-6v writing-mode-horizontal ${bgColor}`}
+                          className={`text-center border-2 h-6v ${bgColor}`}
                         >
                           {alphabet}
                         </td>

--- a/src/components/contents/PointsContent.tsx
+++ b/src/components/contents/PointsContent.tsx
@@ -46,7 +46,7 @@ export const PointsContent: VFC<Props> = ({
         <div className="w-9/10 max-w-screen-sm overflow-x-auto mx-auto mt-2 ">
           <table className="h-60v table-fixed whitespace-nowrap text-center mx-auto">
             <thead>
-              <tr className="bg-gray-400 text-white font-thin h-6v border-2">
+              <tr className="bg-gray-400 text-white h-6v border-2">
                 <th className="w-24 max-w-sm">ゲーム数</th>
                 {Array(gameCount)
                   .fill(0)
@@ -60,10 +60,12 @@ export const PointsContent: VFC<Props> = ({
             </thead>
             <tbody>
               {organizedScore.map((score, i) => {
+                const fontSize =
+                  usersName[i].length <= 5 ? "text-sm" : "text-xs";
                 const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
                 return (
                   <tr key={i} className={` border-2 ${bgColor}`}>
-                    <th>{usersName[i]}</th>
+                    <th className={`${fontSize}`}>{usersName[i]}</th>
                     {score.map((value, j) => (
                       <td key={j} className="border-2">
                         {value}
@@ -104,20 +106,22 @@ export const PointsContent: VFC<Props> = ({
             </thead>
             <tbody>
               {allScore.map((score, i) => {
+                const fontSize =
+                  usersName[i].length <= 5 ? "text-sm" : "text-xs";
                 const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
                 return (
                   <tr key={i} className={`border-2 ${bgColor}`}>
-                    <th>{usersName[i]}</th>
-                    <th className="border-2">
+                    <th className={`${fontSize}`}>{usersName[i]}</th>
+                    <td className="border-2">
                       {score[`game${openedDetail}`].act}
-                    </th>
-                    <th className="border-2">
+                    </td>
+                    <td className="border-2">
                       {score[`game${openedDetail}`].answer}
-                    </th>
-                    <th>
+                    </td>
+                    <td>
                       {score[`game${openedDetail}`].act +
                         score[`game${openedDetail}`].answer}
-                    </th>
+                    </td>
                   </tr>
                 );
               })}

--- a/src/components/contents/PointsContent.tsx
+++ b/src/components/contents/PointsContent.tsx
@@ -3,9 +3,29 @@ import { ThirdButton } from "../Buttons";
 
 type Props = {
   usersName: Array<string>;
+  allScore: Array<any>;
+  gameCount: number;
 };
 
-export const PointsContent: VFC<Props> = ({ usersName }) => {
+export const PointsContent: VFC<Props> = ({
+  usersName,
+  allScore,
+  gameCount,
+}) => {
+  // 得点一覧表の配列
+  const organizedScore: Array<Array<number>> = allScore.map((value, i) => {
+    const scoreList: Array<number> = [];
+    let sum = 0;
+    for (let j = 1; j <= Object.keys(value).length; j++) {
+      const score = value[`game${j}`];
+      const total = score.act + score.answer;
+      sum = sum + total;
+      scoreList.push(score.act + score.answer);
+    }
+    scoreList.push(sum);
+    return scoreList;
+  });
+
   const [openedDetail, setOpenedDetail] = useState<false | number>(false);
   const onClickDetailButton = (num: number) => {
     setOpenedDetail(num);
@@ -14,6 +34,7 @@ export const PointsContent: VFC<Props> = ({ usersName }) => {
   const onClickListButton = () => {
     setOpenedDetail(false);
   };
+  console.log(allScore);
   // 詳細画面内でゲーム数を切り替えるボタンを実装した時用の関数
   // const onClickPreviousButton = () => {
   //   setOpenedDetail((openedDetail as number) - 1);
@@ -22,144 +43,94 @@ export const PointsContent: VFC<Props> = ({ usersName }) => {
   return (
     <>
       {openedDetail === false && (
-        <div className="w-9/10 overflow-x-scroll mx-auto mt-2">
-          <table className="table-fixed bg-white border-2 whitespace-nowrap writing-mode-vertical-lr">
+        <div className="w-9/10 max-w-screen-sm overflow-x-auto mx-auto mt-2 ">
+          <table className="h-60v table-fixed whitespace-nowrap text-center mx-auto">
             <thead>
-              <tr>
-                <th className="w-20 h-6v writing-mode-horizontal font-thin sticky left-0 z-10 bg-gray-400 text-white">
-                  ゲーム数
-                </th>
-                {usersName.map((name, i) => {
-                  const fontSize = name.length <= 5 ? "text-sm" : "text-xs";
-                  const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
-                  return (
-                    <th
-                      className={`border-2 h-6v writing-mode-horizontal sticky left-0 z-10 ${fontSize} ${bgColor}`}
-                      key={name}
-                    >
-                      {name}
+              <tr className="bg-gray-400 text-white font-thin h-6v border-2">
+                <th className="w-24 max-w-sm">ゲーム数</th>
+                {Array(gameCount)
+                  .fill(0)
+                  .map((_, i) => (
+                    <th key={i} className="w-12 border-2">
+                      {i + 1}
                     </th>
-                  );
-                })}
-                <th className="bg-white border-2 z-10 sticky left-0" />
+                  ))}
+                <th className="w-12">合計</th>
               </tr>
             </thead>
             <tbody>
-              {usersName.map((_, i) => {
+              {organizedScore.map((score, i) => {
+                const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
                 return (
-                  <tr key={i}>
-                    <th className="w-12 border-2 h-6v writing-mode-horizontal bg-gray-400 text-white">
-                      {i + 1}
-                    </th>
-                    {["13", "12", "10", "8", "11", "13", "10", "9"].map(
-                      (num, j) => {
-                        const bgColor =
-                          j % 2 === 1 ? "bg-white" : "bg-gray-100";
-                        return (
-                          <td
-                            key={j}
-                            className={`text-center border-2 h-6v writing-mode-horizontal ${bgColor}`}
-                          >
-                            {num}
-                          </td>
-                        );
-                      }
-                    )}
-                    <td className="border-2">
+                  <tr key={i} className={` border-2 ${bgColor}`}>
+                    <th>{usersName[i]}</th>
+                    {score.map((value, j) => (
+                      <td key={j} className="border-2">
+                        {value}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td />
+                {Array(gameCount)
+                  .fill(0)
+                  .map((_, i) => (
+                    <td className="h-8v" key={i}>
                       <ThirdButton
                         text={"詳細"}
                         onClick={() => onClickDetailButton(i + 1)}
                       />
                     </td>
-                  </tr>
-                );
-              })}
-            </tbody>
+                  ))}
+              </tr>
+            </tfoot>
           </table>
         </div>
       )}
       {openedDetail !== false && (
-        <div className="w-9/10 mx-auto mt-2">
-          <table className="mx-auto table-fixed bg-white border-2 whitespace-nowrap writing-mode-vertical-lr">
+        <div className="w-9/10 max-w-screen-sm overflow-x-auto mx-auto mt-2 ">
+          <table className="w-full h-60v table-fixed whitespace-nowrap text-center mx-auto">
             <thead>
-              <tr>
-                <th className="w-20 h-6v writing-mode-horizontal font-thin sticky left-0 z-10 bg-gray-400 text-white">
-                  第{openedDetail}ゲーム
-                </th>
-                {usersName.map((name, i) => {
-                  const fontSize = name.length <= 5 ? "text-sm" : "text-xs";
-                  const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
-                  return (
-                    <th
-                      className={`border-2 h-6v writing-mode-horizontal sticky left-0 z-10 ${fontSize} ${bgColor}`}
-                      key={name}
-                    >
-                      {name}
-                    </th>
-                  );
-                })}
+              <tr className="bg-gray-400 text-white font-thin h-6v border-2">
+                <th className="w-1/3">第{openedDetail}ゲーム</th>
+                <th className="w-1/4 border-2">演技</th>
+                <th className="w-1/4 border-2">回答</th>
+                <th className="w-1/4">合計</th>
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <th className="w-16 border-2 h-6v writing-mode-horizontal bg-gray-400 text-white">
-                  演技
-                </th>
-                {["13", "12", "10", "8", "11", "13", "10", "9"].map(
-                  (num, i) => {
-                    const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
-                    return (
-                      <td
-                        key={i}
-                        className={`text-center border-2 h-6v writing-mode-horizontal ${bgColor}`}
-                      >
-                        {num}
-                      </td>
-                    );
-                  }
-                )}
-              </tr>
-              <tr>
-                <th className="w-16 border-2 h-6v writing-mode-horizontal bg-gray-400 text-white">
-                  回答
-                </th>
-                {["13", "12", "10", "8", "11", "13", "10", "9"].map(
-                  (num, i) => {
-                    const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
-                    return (
-                      <td
-                        key={i}
-                        className={`text-center border-2 h-6v writing-mode-horizontal ${bgColor}`}
-                      >
-                        {num}
-                      </td>
-                    );
-                  }
-                )}
-              </tr>
-              <tr>
-                <th className="w-16 border-2 h-6v writing-mode-horizontal bg-gray-400 text-white">
-                  合計点
-                </th>
-                {["13", "12", "10", "8", "11", "13", "10", "9"].map(
-                  (num, i) => {
-                    const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
-                    return (
-                      <td
-                        key={i}
-                        className={`text-center border-2 h-6v writing-mode-horizontal ${bgColor}`}
-                      >
-                        {num}
-                      </td>
-                    );
-                  }
-                )}
-              </tr>
+              {allScore.map((score, i) => {
+                const bgColor = i % 2 === 1 ? "bg-white" : "bg-gray-100";
+                return (
+                  <tr key={i} className={`border-2 ${bgColor}`}>
+                    <th>{usersName[i]}</th>
+                    <th className="border-2">
+                      {score[`game${openedDetail}`].act}
+                    </th>
+                    <th className="border-2">
+                      {score[`game${openedDetail}`].answer}
+                    </th>
+                    <th>
+                      {score[`game${openedDetail}`].act +
+                        score[`game${openedDetail}`].answer}
+                    </th>
+                  </tr>
+                );
+              })}
             </tbody>
+            <tfoot>
+              <tr>
+                <td />
+                <td className="h-8v">
+                  <ThirdButton text="一覧へ戻る" onClick={onClickListButton} />
+                </td>
+              </tr>
+            </tfoot>
           </table>
-          <div className="text-center mt-2">
-            <ThirdButton text="一覧へ戻る" onClick={onClickListButton} />
-          </div>
         </div>
       )}
     </>

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { GameTabs } from "../components/GameTabs";
 import { Information } from "../components/Information";
 import { ThemeContent } from "../components/contents/ThemeContent";
@@ -19,6 +19,7 @@ import { browserBackProtection } from "../utils/browserBackProtection";
 import { sendAnswer } from "../utils/firestore/sendAnswer";
 import { createAlphabetArray } from "../utils/createArray";
 import { calculateScore } from "../utils/calculateScore";
+import { updateScore } from "../utils/firestore/updateScore";
 
 type Info = {
   userName: string;
@@ -28,8 +29,9 @@ type Info = {
 type Tab = "theme" | "answers" | "points";
 
 export const Game = () => {
-  const { userName, roomId, userId }: Info =
-    getObjFromSessionStorage("userInfo");
+  const { userName, roomId, userId }: Info = useMemo(() => {
+    return getObjFromSessionStorage("userInfo");
+  }, []);
 
   const [currentGameCount, setCurrentGameCount] = useState<number>(0);
   const [usersName, setUsersName] = useState<Array<string>>([]);
@@ -157,6 +159,7 @@ export const Game = () => {
           correctAnswer,
           scoreArray
         );
+        updateScore(roomId, userId, scoreArray[userActorNumber!]);
 
         if (!unmount) {
           setAllAnswers(answersArray);
@@ -174,6 +177,8 @@ export const Game = () => {
     fetchRoom,
     orderByAllUsers,
     roomId,
+    userActorNumber,
+    userId,
     usersName,
   ]);
 

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -18,6 +18,7 @@ import { db } from "../service/firebase";
 import { browserBackProtection } from "../utils/browserBackProtection";
 import { sendAnswer } from "../utils/firestore/sendAnswer";
 import { createAlphabetArray } from "../utils/createArray";
+import { calculateScore } from "../utils/calculateScore";
 
 type Info = {
   userName: string;
@@ -150,24 +151,12 @@ export const Game = () => {
           return data.score;
         });
         const correctAnswer = roomData!.correctAnswer;
-        const gameNum = `game${currentGameCount}`;
-        // 計算
-        // correctAnswerとanswersArrayをひとつずつ比べて、文字が一致する数とインデックス番号を取り出す
-        // actScore = 文字が一致した数, answerScoreインデックス番号を取り出した回数
-        let matchedNumbers: Array<number> = [];
-        answersArray.forEach((answers, i) => {
-          const point = { act: 0, answer: 0 };
-          answers.forEach((value, i) => {
-            if (value === correctAnswer[i]) {
-              point.answer++;
-              matchedNumbers.push(i);
-            }
-          });
-          scoreArray[i][gameNum] = { ...point };
-        });
-        matchedNumbers.forEach((number) => {
-          scoreArray[number][gameNum].act = scoreArray[number][gameNum].act + 1;
-        });
+        calculateScore(
+          currentGameCount,
+          answersArray,
+          correctAnswer,
+          scoreArray
+        );
 
         if (!unmount) {
           setAllAnswers(answersArray);

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -73,7 +73,7 @@ export const Game = () => {
     }
   };
 
-  // firestoreからのデータ取得
+  // firestoreからのデータ取得 TODO: フロントから隠蔽する
   const fetchRoom = useCallback(async () => {
     const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
     const roomSnapshot = await getDoc(roomRef);
@@ -222,7 +222,13 @@ export const Game = () => {
           selectAlphabet={selectAlphabet}
         />
       )}
-      {activeTab === "points" && <PointsContent usersName={usersName} />}
+      {activeTab === "points" && (
+        <PointsContent
+          usersName={usersName}
+          allScore={allScore}
+          gameCount={currentGameCount}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -133,26 +133,15 @@ export const Game = () => {
   }, [fetchRoom, fetchUser, orderByAllUsers, roomId]);
 
   useEffect(() => {
-    const usersRef = collection(db, `hgs/v1/rooms/${roomId}/users`);
     let unmount = false;
     currentActorNumber !== 0 &&
       currentActorNumber === usersName.length &&
       (async () => {
-        const orderByAllUsers = async () => {
-          const usersQuery = query(usersRef, orderBy("actOrder"));
-          const usersSnapshot = await getDocs(usersQuery);
-          return usersSnapshot.docs.map((doc) => {
-            return doc.data();
-          });
-        };
-        const roomData = await fetchRoom();
         const allUsersData = await orderByAllUsers();
         const answersArray = allUsersData.map((data) => {
           return data.answers;
         });
-        // 計算
-        // correctAnswerとanswersArrayをひとつずつ比べて、文字が一致する数とインデックス番号を取り出す
-        // actScore = 文字が一致した数, answerScoreインデックス番号を取り出した回数
+
         if (!unmount) {
           setAllAnswers(answersArray);
           setIsFinished(true);
@@ -162,7 +151,7 @@ export const Game = () => {
     return () => {
       unmount = true;
     };
-  }, [currentActorNumber, roomId, usersName]);
+  }, [currentActorNumber, fetchRoom, orderByAllUsers, roomId, usersName]);
 
   return (
     <>

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -189,7 +189,7 @@ export const Game = () => {
         userName={userName}
         userAlphabet={userAlphabet}
       />
-      {isFinished ? (
+      {currentActorNumber !== 0 && currentActorNumber === usersName.length ? (
         <p className="h-10v flex justify-center items-center text-vivid-red">
           全員の演技が終わりました
           <br />

--- a/src/utils/calculateScore.ts
+++ b/src/utils/calculateScore.ts
@@ -1,0 +1,27 @@
+// 得点計算用の関数 正しい回答×1pt加算、自分の演技を当てた人の数×1pt加算
+// Firestoreから取得した過去データと現在のデータを合わせて、以下のように整形する
+// [{game0: {act: 1, answer: 0}, game1: {act: 1, answer: 0}, game2: {act: 0, answer: 2}},{...},{...}]
+export const calculateScore = (
+  gameCount: number,
+  answers: Array<Array<string>>,
+  correctAnswer: Array<string>,
+  scores: Array<any>
+) => {
+  const gameNum = `game${gameCount}`;
+  let matchedNumbers: Array<number> = [];
+
+  answers.forEach((answers, i) => {
+    const point = { act: 0, answer: 0 };
+    answers.forEach((value, i) => {
+      if (value === correctAnswer[i]) {
+        point.answer++;
+        matchedNumbers.push(i);
+      }
+    });
+    scores[i][gameNum] = { ...point };
+  });
+
+  matchedNumbers.forEach((number) => {
+    scores[number][gameNum].act++;
+  });
+};

--- a/src/utils/firestore/addGuestUser.ts
+++ b/src/utils/firestore/addGuestUser.ts
@@ -17,8 +17,7 @@ export const addGuestUser = async (roomId: string, userName: string) => {
     isHost: false,
     actOrder: null,
     answers: [],
-    actScore: null,
-    answerScore: null,
+    score: null,
   });
   return usersRef.id;
 };

--- a/src/utils/firestore/addGuestUser.ts
+++ b/src/utils/firestore/addGuestUser.ts
@@ -17,7 +17,7 @@ export const addGuestUser = async (roomId: string, userName: string) => {
     isHost: false,
     actOrder: null,
     answers: [],
-    score: null,
+    score: {},
   });
   return usersRef.id;
 };

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -17,8 +17,7 @@ export const createNewRoom = async (name: string) => {
     isHost: true,
     actOrder: null,
     answers: [],
-    actScore: null,
-    answerScore: null,
+    score: null,
   });
   return {
     roomId: roomsRef.id,

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -17,7 +17,7 @@ export const createNewRoom = async (name: string) => {
     isHost: true,
     actOrder: null,
     answers: [],
-    score: null,
+    score: {},
   });
   return {
     roomId: roomsRef.id,

--- a/src/utils/firestore/updateScore.ts
+++ b/src/utils/firestore/updateScore.ts
@@ -1,0 +1,11 @@
+import { doc, updateDoc } from "@firebase/firestore";
+import { db } from "../../service/firebase";
+
+export const updateScore = async (
+  roomId: string,
+  userId: string,
+  userScore: any
+) => {
+  const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
+  await updateDoc(userRef, { score: userScore });
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,6 +33,8 @@ module.exports = {
         "80v": "80vh",
         "90v": "90vh",
         "100v": "100vh",
+        // prettier-ignore
+        "84": "21rem",
       },
       maxHeight: {
         0: "0",


### PR DESCRIPTION
Firestoreに保存された回答を取得し、全員分の点数を計算。
各参加者が、自分の分の点数をFirestoreに保存。

回答と点数の配列を表として表示。
Chromeで正常に表示された表がSafariではスタイルが崩れてしまっていたため、スタイルを修正。