### PR TITLE
複数のFirestore更新処理をバッチ書き込み化

### DIFF
--- a/src/pages/CreateRoom.tsx
+++ b/src/pages/CreateRoom.tsx
@@ -1,3 +1,4 @@
+import { message } from "antd";
 import { ChangeEvent, useState, VFC } from "react";
 import { useHistory } from "react-router";
 import { PrimaryButton } from "../components/Buttons";
@@ -23,7 +24,7 @@ export const CreateRoom: VFC = () => {
       history.push("/host-entrance");
     } catch (e) {
       console.log(e);
-      alert("通信エラーです。もう一度お試しください");
+      message.error("通信エラーです。もう一度お試しください");
     }
   };
 

--- a/src/pages/GuestEntrance.tsx
+++ b/src/pages/GuestEntrance.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, VFC } from "react";
+import { useCallback, useEffect, useState, VFC } from "react";
 import { useHistory } from "react-router";
 import { SecondButton } from "../components/Buttons";
 import { ConfirmModal } from "../components/Modals";
@@ -8,6 +8,7 @@ import { doc, onSnapshot } from "@firebase/firestore";
 import { db } from "../service/firebase";
 import { getObjFromSessionStorage } from "../utils/getObjFromSessionStorage";
 import { browserBackProtection } from "../utils/browserBackProtection";
+import { message } from "antd";
 
 export const GuestEntrance: VFC = () => {
   const { userName, roomId, userId } = getObjFromSessionStorage("userInfo");
@@ -21,11 +22,15 @@ export const GuestEntrance: VFC = () => {
     setIsOpen(false);
   };
 
-  const returnToTopPage = () => {
-    removeUser(roomId, userName, userId);
-    sessionStorage.clear();
-    history.push("/");
-  };
+  const returnToTopPage = useCallback(() => {
+    try {
+      removeUser(roomId, userName, userId);
+      sessionStorage.clear();
+      history.push("/");
+    } catch {
+      message.error("通信エラーです。もう一度お試しください");
+    }
+  }, [history, roomId, userId, userName]);
 
   useEffect(() => {
     browserBackProtection();
@@ -36,7 +41,7 @@ export const GuestEntrance: VFC = () => {
         if (data.isDuringGame === true) history.push("/game");
       }
     });
-  }, [roomId]);
+  }, [history, returnToTopPage, roomId]);
 
   return (
     <>

--- a/src/utils/firestore/addGuestUser.ts
+++ b/src/utils/firestore/addGuestUser.ts
@@ -1,23 +1,18 @@
-import {
-  arrayUnion,
-  collection,
-  doc,
-  setDoc,
-  updateDoc,
-} from "@firebase/firestore";
+import { arrayUnion, collection, doc, writeBatch } from "@firebase/firestore";
 import { db } from "../../service/firebase";
 
 export const addGuestUser = async (roomId: string, userName: string) => {
-  // TODO:トランザクション
   const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
   const usersRef = doc(collection(db, `hgs/v1/rooms/${roomId}/users`));
-  await setDoc(usersRef, {
+  const batch = writeBatch(db);
+  batch.set(usersRef, {
     displayName: userName,
     isHost: false,
     actOrder: null,
     answers: [],
     score: {},
   });
-  await updateDoc(roomRef, { usersName: arrayUnion(userName) });
+  batch.update(roomRef, { usersName: arrayUnion(userName) });
+  await batch.commit();
   return usersRef.id;
 };

--- a/src/utils/firestore/createNewRoom.ts
+++ b/src/utils/firestore/createNewRoom.ts
@@ -1,10 +1,16 @@
-import { collection, doc, serverTimestamp, setDoc } from "@firebase/firestore";
+import {
+  collection,
+  doc,
+  serverTimestamp,
+  writeBatch,
+} from "@firebase/firestore";
 import { db } from "../../service/firebase";
 
 export const createNewRoom = async (name: string) => {
   const roomsRef = doc(collection(db, "hgs/v1/rooms"));
   const usersRef = doc(collection(db, `hgs/v1/rooms/${roomsRef.id}/users`));
-  await setDoc(roomsRef, {
+  const batch = writeBatch(db);
+  batch.set(roomsRef, {
     createdAt: serverTimestamp(),
     usersName: [name],
     gameCount: 0,
@@ -12,13 +18,14 @@ export const createNewRoom = async (name: string) => {
     themeImg: "",
     correctAnswer: [],
   });
-  await setDoc(usersRef, {
+  batch.set(usersRef, {
     displayName: name,
     isHost: true,
     actOrder: null,
     answers: [],
     score: {},
   });
+  await batch.commit();
   return {
     roomId: roomsRef.id,
     userId: usersRef.id,

--- a/src/utils/firestore/removeUser.ts
+++ b/src/utils/firestore/removeUser.ts
@@ -1,4 +1,4 @@
-import { arrayRemove, deleteDoc, doc, updateDoc } from "@firebase/firestore";
+import { arrayRemove, doc, writeBatch } from "@firebase/firestore";
 import { db } from "../../service/firebase";
 
 export const removeUser = async (
@@ -6,9 +6,10 @@ export const removeUser = async (
   userName: string,
   userId: string
 ) => {
-  // TODO:トランザクション
+  const batch = writeBatch(db);
   const roomRef = doc(db, `hgs/v1/rooms/${roomId}`);
-  await updateDoc(roomRef, { usersName: arrayRemove(userName) });
   const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
-  await deleteDoc(userRef);
+  batch.delete(userRef);
+  batch.update(roomRef, { usersName: arrayRemove(userName) });
+  await batch.commit();
 };

--- a/src/utils/firestore/sendAnswer.ts
+++ b/src/utils/firestore/sendAnswer.ts
@@ -1,4 +1,5 @@
 import { arrayUnion, doc, updateDoc } from "@firebase/firestore";
+import { message } from "antd";
 import { db } from "../../service/firebase";
 
 export const sendAnswer = async (
@@ -6,9 +7,13 @@ export const sendAnswer = async (
   userId: string,
   answer: string
 ) => {
-  const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
-  await updateDoc(userRef, {
-    answers: arrayUnion(answer),
-  });
-  console.log("send answer");
+  try {
+    const userRef = doc(db, `hgs/v1/rooms/${roomId}/users/${userId}`);
+    await updateDoc(userRef, {
+      answers: arrayUnion(answer),
+    });
+    console.log("send answer");
+  } catch {
+    message.error("通信エラーです。もう一度お試しください");
+  }
 };


### PR DESCRIPTION
データを読み込む必要がない処理はトランザクションではなくバッチ書き込みを採用。
エラーハンドリングも追加。