### PR TITLE
[update]ロゴをクリックするとトップページへ遷移、ゲーム中に戻る場合は確認モーダルを開く

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,40 @@
 import { VFC } from "react";
-import { Link } from "react-router-dom";
+import { Link, useHistory, useLocation } from "react-router-dom";
 import { Menu, MenuItem, MenuButton } from "@szhsin/react-menu";
 import "@szhsin/react-menu/dist/index.css";
+import { useModals } from "../hooks/useModals";
+import { ConfirmModal } from "./Modals";
 
 export const Header: VFC = () => {
+  const { isOpen, openModal, closeModal } = useModals();
+  const location = useLocation();
+  const history = useHistory();
+  const returnToTopPage = () => {
+    closeModal();
+    history.push("/");
+  };
+  const checkLocation = () => {
+    if (location.pathname.match(/host-entrance|\/guest-entrance|\/game/)) {
+      openModal();
+    } else {
+      returnToTopPage();
+    }
+  };
+
   return (
     <>
       <div className="flex justify-center h-8 p-0.5 bg-yellow-300">
-        <h1 className="text-xl font-medium text-white">HGS</h1>
+        <button
+          onClick={checkLocation}
+          className="text-xl font-medium text-white"
+        >
+          HGS
+        </button>
       </div>
       <Menu
         menuButton={
           <MenuButton className="sm:text-lg absolute right-2 top-1 text-yellow-50">
-            メニュー
+            MENU
           </MenuButton>
         }
         direction={"bottom"}
@@ -20,11 +42,17 @@ export const Header: VFC = () => {
       >
         <div className="underline text-sm text-gray-500">
           <MenuItem>
-            <Link to="/">トップ画面へ</Link>
+            <button onClick={checkLocation}>トップ画面へ</button>
           </MenuItem>
           <MenuItem>使い方をみる</MenuItem>
         </div>
       </Menu>
+      <ConfirmModal
+        isOpen={isOpen === true}
+        onClose={closeModal}
+        text={"トップページへ戻りますか？"}
+        onClick={returnToTopPage}
+      />
     </>
   );
 };


### PR DESCRIPTION
ユーザーがゲーム中にトップページに戻るのは望ましくない（Firestoreに不要なデータが残るため）。
戻るのを禁止はしないが、確認モーダルを開くようにした。